### PR TITLE
Upgrade singer-python, google-cloud to fix requirement mismatch error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,11 @@ setup(name='target-bigquery',
       py_modules=['target_bigquery'],
       install_requires=[
           'jsonschema==2.6.0',
-          'singer-python==1.5.0',
-          'google-api-python-client==1.6.2',
-          'google-cloud==0.32.0'
+          'singer-python>=1.5.0',
+          'google-api-python-client>=1.6.2',
+          'google-cloud>=0.34.0',
+          'google-cloud-bigquery>=1.9.0',
+          'oauth2client',
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
Not sure if you've deliberately pinned to `singer-python==1.5.0`, or if that's an incidental detail, but `target-bigquery` didn't work out of the box for me (see #6).

Fixes: #6

Note that I've snuck in a change to make the write-disposition configurable, since I'm using https://github.com/singer-io/tap-mysql#full-table; LMK if you want to strip that out / split the MR.

I've tested the `persist_lines_job` branch, and it truncates correctly.