### PR TITLE
Add ability to bypass record validation.

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,5 +1,6 @@
 {
     "project_id": "bigquery-public-data",
     "dataset_id": "samples",
-    "table_id": "github_timeline"
+    "table_id": "github_timeline",
+    "validate_records": true
 }


### PR DESCRIPTION
I found that a tap I was using (`tap-mysql`) emitted schema that actually failed some records due to floating point rounding.
The bigger point here is that I'd like to firehose my existing data into BigQuery without regards to whether the data matches the jsonschema. So I'm adding a config option to disable that.