### PR TITLE
Fix logging

### DIFF
--- a/target_bigquery.py
+++ b/target_bigquery.py
@@ -261,7 +261,7 @@ def persist_lines_stream(project_id, dataset_id, lines=None, validate_records=Tr
             logging.info('Loaded {} row(s) into {}:{}'.format(rows[table], dataset_id, table, tables[table].path))
             emit_state(state)
         else:
-            logging.error('Errors:', errors[table], sep=" ")
+            logging.error('Errors: %s', errors[table])
 
     return state
 

--- a/target_bigquery.py
+++ b/target_bigquery.py
@@ -258,7 +258,7 @@ def persist_lines_stream(project_id, dataset_id, lines=None, validate_records=Tr
 
     for table in errors.keys():
         if not errors[table]:
-            logging.info('Loaded {} row(s) into {}:{}'.format(rows[table], dataset_id, table, tables[table].path))
+            logging.info("Loaded {} row(s) from {} into {}:{}".format(rows[table], dataset_id, table, tables[table].path))
             emit_state(state)
         else:
             logging.error('Errors: %s', errors[table])


### PR DESCRIPTION
I stumbled over this issue when attempting to use the target using an invalid schema. With these lines in its current state, the error that is presented is instead a line that states that the operator `sep=" "` is not a valid argument.

I've made a fix that works in my local environment and successfully presents the issues I had with the schema fields.