### PR TITLE
Fix decimal.decimal json.dumps issue

### DIFF
--- a/target_bigquery.py
+++ b/target_bigquery.py
@@ -261,7 +261,7 @@ def persist_lines_stream(project_id, dataset_id, lines=None, validate_records=Tr
             logging.info('Loaded {} row(s) into {}:{}'.format(rows[table], dataset_id, table, tables[table].path))
             emit_state(state)
         else:
-            logging.error('Errors:', errors[table], sep=" ")
+            logging.error('Errors: %s', errors[table])
 
     return state
 

--- a/target_bigquery.py
+++ b/target_bigquery.py
@@ -258,7 +258,7 @@ def persist_lines_stream(project_id, dataset_id, lines=None, validate_records=Tr
 
     for table in errors.keys():
         if not errors[table]:
-            logging.info('Loaded {} row(s) into {}:{}'.format(rows[table], dataset_id, table, tables[table].path))
+            logging.info("Loaded {} row(s) from {} into {}:{}".format(rows[table], dataset_id, table, tables[table].path))
             emit_state(state)
         else:
             logging.error('Errors: %s', errors[table])

--- a/target_bigquery.py
+++ b/target_bigquery.py
@@ -26,30 +26,38 @@ from google.api_core import exceptions
 
 try:
     parser = argparse.ArgumentParser(parents=[tools.argparser])
-    parser.add_argument('-c', '--config', help='Config file', required=True)
+    parser.add_argument("-c", "--config", help="Config file", required=True)
     flags = parser.parse_args()
 
 except ImportError:
     flags = None
 
-logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
+logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)
 logger = singer.get_logger()
 
-SCOPES = ['https://www.googleapis.com/auth/bigquery','https://www.googleapis.com/auth/bigquery.insertdata']
-CLIENT_SECRET_FILE = 'client_secret.json'
-APPLICATION_NAME = 'Singer BigQuery Target'
+SCOPES = [
+    "https://www.googleapis.com/auth/bigquery",
+    "https://www.googleapis.com/auth/bigquery.insertdata",
+]
+CLIENT_SECRET_FILE = "client_secret.json"
+APPLICATION_NAME = "Singer BigQuery Target"
 
-StreamMeta = collections.namedtuple('StreamMeta', ['schema', 'key_properties', 'bookmark_properties'])
+StreamMeta = collections.namedtuple(
+    "StreamMeta", ["schema", "key_properties", "bookmark_properties"]
+)
+
 
 def emit_state(state):
     if state is not None:
         line = json.dumps(state)
-        logger.debug('Emitting state {}'.format(line))
+        logger.debug("Emitting state {}".format(line))
         sys.stdout.write("{}\n".format(line))
         sys.stdout.flush()
 
+
 def clear_dict_hook(items):
-    return {k: v if v is not None else '' for k, v in items}
+    return {k: v if v is not None else "" for k, v in items}
+
 
 def define_schema(field, name):
     schema_name = name
@@ -58,56 +66,65 @@ def define_schema(field, name):
     schema_description = None
     schema_fields = ()
 
-    if 'type' not in field and 'anyOf' in field:
-        for types in field['anyOf']:
-            if types['type'] == 'null':
-                schema_mode = 'NULLABLE'
+    if "type" not in field and "anyOf" in field:
+        for types in field["anyOf"]:
+            if types["type"] == "null":
+                schema_mode = "NULLABLE"
             else:
                 field = types
-            
-    if isinstance(field['type'], list):
-        if field['type'][0] == "null":
-            schema_mode = 'NULLABLE'
+
+    if isinstance(field["type"], list):
+        if field["type"][0] == "null":
+            schema_mode = "NULLABLE"
         else:
-            schema_mode = 'required'
-        schema_type = field['type'][-1]
+            schema_mode = "required"
+        schema_type = field["type"][-1]
     else:
-        schema_type = field['type']
+        schema_type = field["type"]
     if schema_type == "object":
         schema_type = "RECORD"
         schema_fields = tuple(build_schema(field))
     if schema_type == "array":
-        schema_type = field.get('items').get('type')
+        schema_type = field.get("items").get("type")
         schema_mode = "REPEATED"
         if schema_type == "object":
-          schema_type = "RECORD"
-          schema_fields = tuple(build_schema(field.get('items')))
-
+            schema_type = "RECORD"
+            schema_fields = tuple(build_schema(field.get("items")))
 
     if schema_type == "string":
         if "format" in field:
-            if field['format'] == "date-time":
+            if field["format"] == "date-time":
                 schema_type = "timestamp"
 
-    if schema_type == 'number':
-        schema_type = 'FLOAT'
+    if schema_type == "number":
+        schema_type = "FLOAT"
 
     return (schema_name, schema_type, schema_mode, schema_description, schema_fields)
 
+
 def build_schema(schema):
     SCHEMA = []
-    for key in schema['properties'].keys():
-        
-        if not (bool(schema['properties'][key])):
+    for key in schema["properties"].keys():
+
+        if not (bool(schema["properties"][key])):
             # if we endup with an empty record.
             continue
 
-        schema_name, schema_type, schema_mode, schema_description, schema_fields = define_schema(schema['properties'][key], key)
-        SCHEMA.append(SchemaField(schema_name, schema_type, schema_mode, schema_description, schema_fields))
+        schema_name, schema_type, schema_mode, schema_description, schema_fields = define_schema(
+            schema["properties"][key], key
+        )
+        SCHEMA.append(
+            SchemaField(
+                schema_name, schema_type, schema_mode, schema_description, schema_fields
+            )
+        )
 
     return SCHEMA
 
-def persist_lines_job(project_id, dataset_id, lines=None, truncate=False, validate_records=True):
+
+def persist_lines_job(
+    project_id, dataset_id, lines=None, truncate=False, validate_records=True
+):
     state = None
     schemas = {}
     key_properties = {}
@@ -131,7 +148,11 @@ def persist_lines_job(project_id, dataset_id, lines=None, truncate=False, valida
 
         if isinstance(msg, singer.RecordMessage):
             if msg.stream not in schemas:
-                raise Exception("A record for stream {} was encountered before a corresponding schema".format(msg.stream))
+                raise Exception(
+                    "A record for stream {} was encountered before a corresponding schema".format(
+                        msg.stream
+                    )
+                )
 
             schema = schemas[msg.stream]
 
@@ -139,23 +160,23 @@ def persist_lines_job(project_id, dataset_id, lines=None, truncate=False, valida
                 validate(msg.record, schema)
 
             # NEWLINE_DELIMITED_JSON expects literal JSON formatted data, with a newline character splitting each row.
-            dat = bytes(json.dumps(msg.record) + '\n', 'UTF-8')
+            dat = bytes(json.dumps(msg.record) + "\n", "UTF-8")
 
             rows[msg.stream].write(dat)
-            #rows[msg.stream].write(bytes(str(msg.record) + '\n', 'UTF-8'))
+            # rows[msg.stream].write(bytes(str(msg.record) + '\n', 'UTF-8'))
 
             state = None
 
         elif isinstance(msg, singer.StateMessage):
-            logger.debug('Setting state to {}'.format(msg.value))
+            logger.debug("Setting state to {}".format(msg.value))
             state = msg.value
 
         elif isinstance(msg, singer.SchemaMessage):
-            table = msg.stream 
+            table = msg.stream
             schemas[table] = msg.schema
             key_properties[table] = msg.key_properties
-            #tables[table] = bigquery.Table(dataset.table(table), schema=build_schema(schemas[table]))
-            rows[table] = TemporaryFile(mode='w+b')
+            # tables[table] = bigquery.Table(dataset.table(table), schema=build_schema(schemas[table]))
+            rows[table] = TemporaryFile(mode="w+b")
             errors[table] = None
             # try:
             #     tables[table] = bigquery_client.create_table(tables[table])
@@ -182,10 +203,10 @@ def persist_lines_job(project_id, dataset_id, lines=None, truncate=False, valida
         rows[table].seek(0)
         logger.info("loading {} to Bigquery.\n".format(table))
         load_job = bigquery_client.load_table_from_file(
-            rows[table], table_ref, job_config=load_config)
+            rows[table], table_ref, job_config=load_config
+        )
         logger.info("loading job {}".format(load_job.job_id))
         logger.info(load_job.result())
-
 
     # for table in errors.keys():
     #     if not errors[table]:
@@ -194,6 +215,7 @@ def persist_lines_job(project_id, dataset_id, lines=None, truncate=False, valida
     #         print('Errors:', errors[table], sep=" ")
 
     return state
+
 
 def persist_lines_stream(project_id, dataset_id, lines=None, validate_records=True):
     state = None
@@ -208,7 +230,9 @@ def persist_lines_stream(project_id, dataset_id, lines=None, validate_records=Tr
     dataset_ref = bigquery_client.dataset(dataset_id)
     dataset = Dataset(dataset_ref)
     try:
-        dataset = bigquery_client.create_dataset(Dataset(dataset_ref)) or Dataset(dataset_ref)
+        dataset = bigquery_client.create_dataset(Dataset(dataset_ref)) or Dataset(
+            dataset_ref
+        )
     except exceptions.Conflict:
         pass
 
@@ -221,27 +245,35 @@ def persist_lines_stream(project_id, dataset_id, lines=None, validate_records=Tr
 
         if isinstance(msg, singer.RecordMessage):
             if msg.stream not in schemas:
-                raise Exception("A record for stream {} was encountered before a corresponding schema".format(msg.stream))
+                raise Exception(
+                    "A record for stream {} was encountered before a corresponding schema".format(
+                        msg.stream
+                    )
+                )
 
             schema = schemas[msg.stream]
 
             if validate_records:
                 validate(msg.record, schema)
 
-            errors[msg.stream] = bigquery_client.insert_rows_json(tables[msg.stream], [msg.record])
+            errors[msg.stream] = bigquery_client.insert_rows_json(
+                tables[msg.stream], [msg.record]
+            )
             rows[msg.stream] += 1
 
             state = None
 
         elif isinstance(msg, singer.StateMessage):
-            logger.debug('Setting state to {}'.format(msg.value))
+            logger.debug("Setting state to {}".format(msg.value))
             state = msg.value
 
         elif isinstance(msg, singer.SchemaMessage):
-            table = msg.stream 
+            table = msg.stream
             schemas[table] = msg.schema
             key_properties[table] = msg.key_properties
-            tables[table] = bigquery.Table(dataset.table(table), schema=build_schema(schemas[table]))
+            tables[table] = bigquery.Table(
+                dataset.table(table), schema=build_schema(schemas[table])
+            )
             rows[table] = 0
             errors[table] = None
             try:
@@ -258,58 +290,77 @@ def persist_lines_stream(project_id, dataset_id, lines=None, validate_records=Tr
 
     for table in errors.keys():
         if not errors[table]:
-            logging.info("Loaded {} row(s) from {} into {}:{}".format(rows[table], dataset_id, table, tables[table].path))
+            logging.info(
+                "Loaded {} row(s) from {} into {}:{}".format(
+                    rows[table], dataset_id, table, tables[table].path
+                )
+            )
             emit_state(state)
         else:
-            logging.error('Errors: %s', errors[table])
+            logging.error("Errors: %s", errors[table])
 
     return state
 
+
 def collect():
     try:
-        version = pkg_resources.get_distribution('target-bigquery').version
-        conn = http.client.HTTPConnection('collector.singer.io', timeout=10)
+        version = pkg_resources.get_distribution("target-bigquery").version
+        conn = http.client.HTTPConnection("collector.singer.io", timeout=10)
         conn.connect()
         params = {
-            'e': 'se',
-            'aid': 'singer',
-            'se_ca': 'target-bigquery',
-            'se_ac': 'open',
-            'se_la': version,
+            "e": "se",
+            "aid": "singer",
+            "se_ca": "target-bigquery",
+            "se_ac": "open",
+            "se_la": version,
         }
-        conn.request('GET', '/i?' + urllib.parse.urlencode(params))
+        conn.request("GET", "/i?" + urllib.parse.urlencode(params))
         conn.getresponse()
         conn.close()
     except:
-        logger.debug('Collection request failed')
+        logger.debug("Collection request failed")
+
 
 def main():
     with open(flags.config) as input:
         config = json.load(input)
 
-    if not config.get('disable_collection', False):
-        logger.info('Sending version information to stitchdata.com. ' +
-                    'To disable sending anonymous usage data, set ' +
-                    'the config parameter "disable_collection" to true')
+    if not config.get("disable_collection", False):
+        logger.info(
+            "Sending version information to stitchdata.com. "
+            + "To disable sending anonymous usage data, set "
+            + 'the config parameter "disable_collection" to true'
+        )
         threading.Thread(target=collect).start()
 
-    if config.get('replication_method') == 'FULL_TABLE':
+    if config.get("replication_method") == "FULL_TABLE":
         truncate = True
     else:
         truncate = False
 
-    validate_records = config.get('validate_records', True)
+    validate_records = config.get("validate_records", True)
 
-    input = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+    input = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8")
 
-    if config.get('stream_data', True):
-        state = persist_lines_stream(config['project_id'], config['dataset_id'], input, validate_records=validate_records)
+    if config.get("stream_data", True):
+        state = persist_lines_stream(
+            config["project_id"],
+            config["dataset_id"],
+            input,
+            validate_records=validate_records,
+        )
     else:
-        state = persist_lines_job(config['project_id'], config['dataset_id'], input, truncate=truncate, validate_records=validate_records)
+        state = persist_lines_job(
+            config["project_id"],
+            config["dataset_id"],
+            input,
+            truncate=truncate,
+            validate_records=validate_records,
+        )
 
     emit_state(state)
     logger.debug("Exiting normally")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/target_bigquery.py
+++ b/target_bigquery.py
@@ -86,6 +86,8 @@ def define_schema(field, name):
         schema_fields = tuple(build_schema(field))
     if schema_type == "array":
         schema_type = field.get("items").get("type")
+        if isinstance(schema_type, list):
+            schema_type = schema_type[-1]
         schema_mode = "REPEATED"
         if schema_type == "object":
             schema_type = "RECORD"


### PR DESCRIPTION
singer-io encourages use of Decimal.decimal for good reason, when encoding and decoding streams.

The first minor issue, is that the default json encoder in Python does not handle this class by default. No big deal, I've had to handle this hundreds of times.

The bigger problem is that the issue arises in the belly of the `google.bigquery.Client.insert_rows_json` function, where it attempts to perform a `json.dumps` and does not handle the `Decimal.decimal` class.

The frustration here, is that a `Decimal.decimal` is enormously expected in the context of the `target-bigquery`, meaning that we can't be the first ones to be hit by it. Basically every `float` put into the system is converted, by default by the singer-tools, to a `Decimal.decimal` on when parsing a new record. We've simply not been seeing any for the fields that can switch types yet.

The AgileCRM schemas specify our potential float fields as `numbers`, meaning they are integer or floats (since they are integer when not set, but floats afterwards - I know, great).

This  fix would adress that limitation in BQ using its ability to retrieve a float as a string, meaning we'd loose no precision due to truncation etc. and the singer defaults of using decimal.Decimal is all good, and we work with it and not against it.