### PR TITLE
Make compatible with Json Schema pattern properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ ENV/
 .mypy_cache/
 
 .vscode/
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ It should be possible to use the oAuth flow to authenticate to GCP as well:
 
 The data will be written to the table specified in your `config.json`.
 
+### JSON Schema compatibility
+
+Singer taps use JSON Schema to describe/validate the data they produce.
+However the [patternProperties](https://json-schema.org/understanding-json-schema/reference/object.html#pattern-properties) 
+feature of this schema standard is not really applicable to BigQuery JSON schema structure. 
+As a workaround we simply convert the values of fields using `patternProperties` to string before loading.
+These columns can then be worked on with [BigQuery JSON functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions).
+
 ---
 
 Copyright &copy; 2018 RealSelf, Inc.

--- a/target_bigquery.py
+++ b/target_bigquery.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import decimal
 import io
 import sys
 import json
@@ -145,6 +146,8 @@ def persist_lines_job(project_id, dataset_id, lines=None, truncate=False, valida
             # NEWLINE_DELIMITED_JSON expects literal JSON formatted data, with a newline character splitting each row.
             new_record = {}
             for key, value in msg.record.items():
+                if isinstance(value, decimal.Decimal):
+                    value = float(value)
                 new_record[fix_name(key)] = value
             dat = bytes(json.dumps(new_record) + '\n', 'UTF-8')
 


### PR DESCRIPTION
This PR also includes commits from #19 which is still not merged. #19 is a base for this PR.

Trying to use this target with `tap-jira` I noticed that the target was not able to handle `patternProperties` feature of the [JSON Schema standard](https://json-schema.org/understanding-json-schema/reference/object.html#pattern-properties).

However in BigQuery JSON schema specification there is no way to represent such field property. So I decided handling it by converting such fields to string both when loading the records and when creating the table schema.

Also with this PR I fixed some minor bugs:
- Handling schema field with no property definition.
- `logging.error()` doesn't have a parameter named `sep`

And lastly I improved `fix_name()` function to comply BigQuery table name constraints completely.