### PR TITLE
Add option handle row metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ celerybeat-schedule
 # dotenv
 .env
 
+# direnv
+.envrc
+
 # virtualenv
 .venv
 venv/

--- a/config.sample.json
+++ b/config.sample.json
@@ -2,5 +2,6 @@
     "project_id": "bigquery-public-data",
     "dataset_id": "samples",
     "table_id": "github_timeline",
-    "validate_records": true
+    "validate_records": true,
+    "add_tap_metadata": false
 }


### PR DESCRIPTION
When `add_tap_metadata` is set to `true` in the config, add the following fields to the table schema and imported data:
+ _sdc_version
+ _sdc_extracted_at
+ _sdc_deleted_at

This allows pulling accurate table information for append-only tables, when the source tap contains updated or deleted rows (e.g. tap-mysql)